### PR TITLE
Task 7

### DIFF
--- a/src/components/pages/admin/PageProductImport/components/CSVFileImport.tsx
+++ b/src/components/pages/admin/PageProductImport/components/CSVFileImport.tsx
@@ -37,6 +37,9 @@ export default function CSVFileImport({url, title}: CSVFileImportProps) {
         url,
         params: {
           name: encodeURIComponent(file.name)
+        },
+        headers: {
+          Authorization: 'Basic ' + localStorage.getItem('authorization_token')
         }
       })
       console.log('File to upload: ', file.name)

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -16,6 +16,17 @@ axios.interceptors.response.use(
     if (error.response.status === 400) {
       alert(error.response.data?.data);
     }
+
+    if (error.response.status === 401) {
+      console.error(JSON.stringify(error));
+      alert(error.message);
+    }
+
+    if (error.response.status === 403) {
+      console.log(JSON.stringify(error));
+      alert(error.message);
+    }
+
     return Promise.reject(error.response);
   }
 );


### PR DESCRIPTION
Original Task: https://github.com/rolling-scopes-school/nodejs-aws-tasks/blob/main/task7-lambda%2Bcognito-authorization/task.md

**Evaluation criteria (each mark includes previous mark criteria)**
5 - update client application to send Authorization: Basic authorization_token header on import. Client should get authorization_token value from browser localStorage https://developer.mozilla.org/ru/docs/Web/API/Window/localStorage authorization_token = localStorage.getItem('authorization_token')
**Additional (optional) tasks**
+1 - Client application should display alerts for the responses in 401 and 403 HTTP statuses. This behavior should be added to the nodejs-aws-fe-main/src/index.tsx file

Back-end pull request: https://github.com/ilya-moskovtsev/nodejs-aws-be/pull/5